### PR TITLE
Advance CI features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,12 @@ jobs:
         - bash -c 'shopt -s globstar; shellcheck **/*.sh'
     - &build
       stage: build
-      env: VERSION=0.17
+      env: VERSION_SHORT=0.17 EXTRA_TAG=latest
       script:
-        - ./build.sh $VERSION
-      after_success:
-        - if [ "$TRAVIS_BRANCH" == "master" ]; then
-            echo "$DOCKER_PASSWORD" | DOCKER login -u "$DOCKER_USERNAME" --password-stdin
-            docker push "factoriotools/docker_factorio_server:$VERSION"
-          fi
+        - ./build.sh $VERSION_SHORT
     - <<: *build
-      env: VERSION=0.16
+      env: VERSION_SHORT=0.16 EXTRA_TAG=stable
     - <<: *build
-      env: VERSION=0.15
+      env: VERSION_SHORT=0.15
     - <<: *build
-      env: VERSION=0.14
+      env: VERSION_SHORT=0.14

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,8 @@ addons:
 jobs:
   include:
     - stage: test
-      env: HADOLINT=${HOME}/hadolint
-      install: curl -sLo ${HADOLINT} $(curl -s https://api.github.com/repos/hadolint/hadolint/releases/latest?access_token=${GITHUB_TOKEN} | jq -r '.assets | .[] | select(.name=="hadolint-Linux-x86_64") | .browser_download_url')
-               && chmod 700 ${HADOLINT}
       script:
-        - git ls-files --exclude='*Dockerfile' --ignored | xargs --max-lines=1 ${HADOLINT}
+        - git ls-files --exclude='*Dockerfile' --ignored | xargs --max-lines=1 -I{} sh -c 'docker run --rm -i -v ${PWD}/.hadolint.yaml:/.hadolint.yaml hadolint/hadolint < "$1"' -- {}
         - bash -c 'shopt -s globstar; shellcheck **/*.sh'
     - &build
       stage: build

--- a/0.17/files/docker-entrypoint.sh
+++ b/0.17/files/docker-entrypoint.sh
@@ -30,7 +30,7 @@ if [ ! -f "$CONFIG/map-settings.json" ]; then
 fi
 
 NRTMPSAVES=$( find -L "$SAVES" -iname \*.tmp.zip -mindepth 1 | wc -l )
-if [ $NRTMPSAVES -gt 0 ]; then
+if [ "$NRTMPSAVES" -gt 0 ]; then
   # Delete incomplete saves (such as after a forced exit)
   rm -f "$SAVES/*.tmp.zip"
 fi
@@ -48,7 +48,7 @@ else
 fi
 
 NRSAVES=$( find -L "$SAVES" -iname \*.zip -mindepth 1 | wc -l )
-if [ $NRSAVES -eq 0 ]; then
+if [ "$NRSAVES" -eq 0 ]; then
   # Generate a new map if no save ZIPs exist
   $SU_EXEC /opt/factorio/bin/x64/factorio \
     --create "$SAVES/_autosave1.zip" \

--- a/build.sh
+++ b/build.sh
@@ -2,19 +2,25 @@
 set -eo pipefail
 
 if [ -z "$1" ]; then
-  echo "Usage: ./build.sh \$VERSION"
+  echo "Usage: ./build.sh \$VERSION_SHORT"
 else
-  VERSION="$1"
+  VERSION_SHORT="$1"
 fi
 
-cd "$VERSION" || exit
+VERSION=$(grep -oP '[0-9]+\.[0-9]+\.[0-9]+' "$VERSION_SHORT/Dockerfile" | head -1)
+cd "$VERSION_SHORT" || exit
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   if [ "$TRAVIS_BRANCH" == "master" ]; then
-    TAG="$VERSION"
+    TAG="$VERSION -t factoriotools/docker_factorio_server:$VERSION_SHORT"
   else
     TAG="$TRAVIS_BRANCH"
   fi
+
+  docker build . -t "factoriotools/docker_factorio_server:$TAG"
+
+  # echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  # docker push "factoriotools/docker_factorio_server:$VERSION"
 fi
 
-docker build . -t "factoriotools/docker_factorio_server:$TAG"
+docker images

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -eox pipefail
 
 if [ -z "$1" ]; then
   echo "Usage: ./build.sh \$VERSION_SHORT"
@@ -8,19 +8,25 @@ else
 fi
 
 VERSION=$(grep -oP '[0-9]+\.[0-9]+\.[0-9]+' "$VERSION_SHORT/Dockerfile" | head -1)
+DOCKER_REPO=factoriotools/docker_factorio_server
 cd "$VERSION_SHORT" || exit
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   if [ "$TRAVIS_BRANCH" == "master" ]; then
-    TAG="$VERSION -t factoriotools/docker_factorio_server:$VERSION_SHORT"
+    TAG="$VERSION -t $DOCKER_REPO:$VERSION_SHORT"
   else
     TAG="$TRAVIS_BRANCH"
   fi
 
-  docker build . -t "factoriotools/docker_factorio_server:$TAG"
+  if [ -n "$EXTRA_TAG" ]; then
+    TAG="$TAG -t $DOCKER_REPO:$EXTRA_TAG"
+  fi
+
+  # shellcheck disable=SC2086
+  docker build . -t $DOCKER_REPO:$TAG
 
   # echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  # docker push "factoriotools/docker_factorio_server:$VERSION"
+  # docker push "$DOCKER_REPO:$VERSION"
 fi
 
 docker images

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-if [ -z "$1" ] ; then
+if [ -z "$1" ]; then
   echo "Usage: ./build.sh \$VERSION"
 else
   VERSION="$1"
@@ -9,4 +9,12 @@ fi
 
 cd "$VERSION" || exit
 
-docker build . -t "factoriotools/docker_factorio_server:$VERSION"
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  if [ "$TRAVIS_BRANCH" == "master" ]; then
+    TAG="$VERSION"
+  else
+    TAG="$TRAVIS_BRANCH"
+  fi
+fi
+
+docker build . -t "factoriotools/docker_factorio_server:$TAG"

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,9 @@ VERSION=$(grep -oP '[0-9]+\.[0-9]+\.[0-9]+' "$VERSION_SHORT/Dockerfile" | head -
 DOCKER_REPO=factoriotools/docker_factorio_server
 cd "$VERSION_SHORT" || exit
 
-if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+if [ "$TRAVIS_PULL_REQUEST" == "true" ]; then
+  TAG="$TRAVIS_PULL_REQUEST_SLUG"
+else
   if [ "$TRAVIS_BRANCH" == "master" ]; then
     TAG="$VERSION -t $DOCKER_REPO:$VERSION_SHORT"
   else

--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,7 @@ docker build . -t $DOCKER_REPO:$TAG
 
 docker images
 
-if [ "$(dirname "$(git diff --name-only HEAD^)" | head -1)" == "$VERSION" ]; then
+if [ "$(dirname "$(git diff --name-only HEAD^)" | head -1)" == "$VERSION" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
   # echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   docker push "$DOCKER_REPO:latest"
 

--- a/build.sh
+++ b/build.sh
@@ -40,4 +40,6 @@ if [ "$(dirname "$(git diff --name-only HEAD^)" | head -1)" == "$VERSION" ]; the
     docker push "$DOCKER_REPO:$VERSION"
     docker push "$DOCKER_REPO:$VERSION_SHORT"
   fi
+
+  curl -X POST https://hooks.microbadger.com/images/factoriotools/factorio/TmmKGNp8jKcFqZvcJhTCIAJVluw=
 fi

--- a/build.sh
+++ b/build.sh
@@ -28,14 +28,15 @@ docker build . -t $DOCKER_REPO:$TAG
 
 docker images
 
-# echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+if [ "dirname $(git diff --name-only HEAD^) | head -1" == "$VERSION" ]; then
+  # echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  docker push "$DOCKER_REPO:latest"
 
-docker push "$DOCKER_REPO:latest"
+  if [ -n "$EXTRA_TAG" ]; then
+    docker push "$DOCKER_REPO:$EXTRA_TAG"
+  fi
 
-if [ -n "$EXTRA_TAG" ]; then
-  docker push "$DOCKER_REPO:$EXTRA_TAG"
-fi
-
-if [ -n "$TRAVIS_TAG" ]; then
-  docker push "$DOCKER_REPO:$VERSION"
+  if [ -n "$TRAVIS_TAG" ]; then
+    docker push "$DOCKER_REPO:$VERSION"
+  fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ docker build . -t $DOCKER_REPO:$TAG
 
 docker images
 
-if [ "dirname $(git diff --name-only HEAD^) | head -1" == "$VERSION" ]; then
+if [ "$(dirname "$(git diff --name-only HEAD^)" | head -1)" == "$VERSION" ]; then
   # echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   docker push "$DOCKER_REPO:latest"
 
@@ -38,5 +38,6 @@ if [ "dirname $(git diff --name-only HEAD^) | head -1" == "$VERSION" ]; then
 
   if [ -n "$TRAVIS_TAG" ]; then
     docker push "$DOCKER_REPO:$VERSION"
+    docker push "$DOCKER_REPO:$VERSION_SHORT"
   fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -21,12 +21,21 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   if [ -n "$EXTRA_TAG" ]; then
     TAG="$TAG -t $DOCKER_REPO:$EXTRA_TAG"
   fi
-
-  # shellcheck disable=SC2086
-  docker build . -t $DOCKER_REPO:$TAG
-
-  # echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  # docker push "$DOCKER_REPO:$VERSION"
 fi
 
+# shellcheck disable=SC2086
+docker build . -t $DOCKER_REPO:$TAG
+
 docker images
+
+# echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+docker push "$DOCKER_REPO:latest"
+
+if [ -n "$EXTRA_TAG" ]; then
+  docker push "$DOCKER_REPO:$EXTRA_TAG"
+fi
+
+if [ -n "$TRAVIS_TAG" ]; then
+  docker push "$DOCKER_REPO:$VERSION"
+fi


### PR DESCRIPTION
This is going to implement some of the requested feature from over here https://github.com/Fankserver/docker_factorio_server_test/issues/3


- [x] Only trigger build for the tag where changes were made, e.g. when we changes something in the 0.17 folder than only the 0.17 tag should be build.
- [x] When a build is triggered it need to build the full (0.17.12) the shorted (0.17) tag.
- [x] latest tag should be only build when the highest version (folder name) is changed.
- [x] The tags (not latest) should be only build when we add a new release (git tag)
- [x] All branches excluding master should build with the tag of the branch name, on all changes.

To see how travis works with those changes take a look here https://travis-ci.org/SuperSandro2000/docker_factorio_server/branches or create some test PR's here https://github.com/SuperSandro2000/docker_factorio_server

These things are still open for @Fank 

- [ ] Update Readme on dockerhub on master changes, https://github.com/moikot/golang-dep/blob/master/.travis/push.sh#L117-L145