### PR TITLE
Allow puid/pgid to be set as environment vars on stable

### DIFF
--- a/0.16/Dockerfile
+++ b/0.16/Dockerfile
@@ -16,8 +16,8 @@ ENV PORT=34197 \
     MODS=/factorio/mods \
     SCENARIOS=/factorio/scenarios \
     SCRIPTOUTPUT=/factorio/script-output \
-    PUID=$PUID \
-    PGID=$PGID
+    PUID="$PUID" \
+    PGID="$PGID"
 
 RUN mkdir -p /opt /factorio && \
     apk add --update --no-cache pwgen su-exec shadow && \

--- a/0.16/Dockerfile
+++ b/0.16/Dockerfile
@@ -20,7 +20,7 @@ ENV PORT=34197 \
     PGID=$PGID
 
 RUN mkdir -p /opt /factorio && \
-    apk add --update --no-cache pwgen && \
+    apk add --update --no-cache pwgen su-exec shadow && \
     apk add --update --no-cache --virtual .build-deps curl && \
     curl -sSL https://www.factorio.com/get-download/$VERSION/headless/linux64 \
         -o /tmp/factorio_headless_x64_$VERSION.tar.xz && \
@@ -42,7 +42,5 @@ VOLUME /factorio
 EXPOSE $PORT/udp $RCON_PORT/tcp
 
 COPY files/ /
-
-USER $USER
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/0.16/Dockerfile
+++ b/0.16/Dockerfile
@@ -15,7 +15,9 @@ ENV PORT=34197 \
     CONFIG=/factorio/config \
     MODS=/factorio/mods \
     SCENARIOS=/factorio/scenarios \
-    SCRIPTOUTPUT=/factorio/script-output
+    SCRIPTOUTPUT=/factorio/script-output \
+    PUID=$PUID \
+    PGID=$PGID
 
 RUN mkdir -p /opt /factorio && \
     apk add --update --no-cache pwgen && \

--- a/0.16/files/docker-entrypoint.sh
+++ b/0.16/files/docker-entrypoint.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 id
 
+FACTORIO_VOL=/factorio
+mkdir -p "$FACTORIO_VOL"
 mkdir -p "$SAVES"
 mkdir -p "$CONFIG"
 mkdir -p "$MODS"
@@ -29,14 +31,26 @@ if find -L "$SAVES" -iname \*.tmp.zip -mindepth 1 -print | grep -q .; then
   rm -f "$SAVES/*.tmp.zip"
 fi
 
+if [ "$(id -u)" = '0' ]; then
+  # Update the User and Group ID based on the PUID/PGID variables
+  usermod -o -u "$PUID" factorio
+  groupmod -o -g "$PGID" factorio
+  # Take ownership of factorio data if running as root
+  chown -R factorio:factorio $FACTORIO_VOL
+  # Drop to the factorio user
+  SU_EXEC="su-exec factorio"
+else
+  SU_EXEC=""
+fi
+
 if ! find -L "$SAVES" -iname \*.zip -mindepth 1 -print | grep -q .; then
-  /opt/factorio/bin/x64/factorio \
+  $SU_EXEC /opt/factorio/bin/x64/factorio \
     --create "$SAVES/_autosave1.zip" \
     --map-gen-settings "$CONFIG/map-gen-settings.json" \
     --map-settings "$CONFIG/map-settings.json"
 fi
 
-exec /opt/factorio/bin/x64/factorio \
+$SU_EXEC /opt/factorio/bin/x64/factorio \
   --port "$PORT" \
   --start-server-load-latest \
   --server-settings "$CONFIG/server-settings.json" \

--- a/0.16/files/docker-entrypoint.sh
+++ b/0.16/files/docker-entrypoint.sh
@@ -36,7 +36,7 @@ if [ "$(id -u)" = '0' ]; then
   usermod -o -u "$PUID" factorio
   groupmod -o -g "$PGID" factorio
   # Take ownership of factorio data if running as root
-  chown -R factorio:factorio $FACTORIO_VOL
+  chown -R factorio:factorio "$FACTORIO_VOL"
   # Drop to the factorio user
   SU_EXEC="su-exec factorio"
 else


### PR DESCRIPTION
I'm running Factorio with shared folders on an instance where I can't set the UID/GID. It looks like this is already setup for latest so wanted to be able to run the same way on stable as well.

https://github.com/factoriotools/factorio-docker/blob/44371283b6dbff377ad0bf55c1d9365289b2794a/0.17/Dockerfile#L19-L20