### PR TITLE
Fixing of port problems.

### DIFF
--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -39,8 +39,6 @@ RUN set -ox pipefail \
 
 VOLUME /factorio
 
-EXPOSE $PORT/udp $RCON_PORT/tcp
-
 COPY files/ /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
EXPOSE 0.0.0.0:$PORT:$PORT/udp 0.0.0.0:$RCON_PORT:$RCON_PORT/tcp

Only with this parameter `--publish 0.0.0.0:34197:34197/udp`, it is possible for me to create a successful connection.
```bash
docker run --rm --publish 0.0.0.0:34197:34197/udp --publish 0.0.0.0:27015:27015/tcp --attach stdout factoriotools/factorio
```
I recommend to remove the line "EXPOSE $PORT/udp $RCON_PORT/tcp completely, because there are so port overlays.
```bash
docker container ps --all --format "{{.Ports}}"
0.0.0.0:20001->20001/tcp, 27015/tcp, 0.0.0.0:30001->30001/udp, 34197/udp
0.0.0.0:20000->20000/tcp, 27015/tcp, 0.0.0.0:30000->30000/udp, 34197/udp
```