### PR TITLE
Allow configuring factorio server to run with a specific save through environment variables

### DIFF
--- a/0.17/files/docker-entrypoint.sh
+++ b/0.17/files/docker-entrypoint.sh
@@ -2,6 +2,10 @@
 set -eoux pipefail
 
 FACTORIO_VOL=/factorio
+LOAD_LATEST_SAVE="${LOAD_LATEST_SAVE:-true}"
+GENERATE_NEW_SAVE="${GENERATE_NEW_SAVE:-false}"
+SAVE_NAME="${SAVE_NAME:-""}"
+
 mkdir -p "$FACTORIO_VOL"
 mkdir -p "$SAVES"
 mkdir -p "$CONFIG"
@@ -50,18 +54,28 @@ else
 fi
 
 NRSAVES=$(find -L "$SAVES" -iname \*.zip -mindepth 1 | wc -l)
-if [[ $NRSAVES -eq 0 ]]; then
-  # Generate a new map if no save ZIPs exist
-  $SU_EXEC /opt/factorio/bin/x64/factorio \
-    --create "$SAVES/_autosave1.zip" \
-    --map-gen-settings "$CONFIG/map-gen-settings.json" \
-    --map-settings "$CONFIG/map-settings.json"
+if [[ $GENERATE_NEW_SAVE != true && $NRSAVES ==  0 ]]; then
+    GENERATE_NEW_SAVE=true
+    SAVE_NAME=_autosave1
 fi
 
-# shellcheck disable=SC2086
-exec $SU_EXEC /opt/factorio/bin/x64/factorio \
+if [[ $GENERATE_NEW_SAVE == true ]]; then
+    if [[ -z "$SAVE_NAME" ]]; then
+        echo "If \$GENERATE_NEW_SAVE is true, you must specify \$SAVE_NAME"
+        exit 1
+    fi
+    if [[ -f "$SAVES/$SAVE_NAME.zip" ]]; then
+        echo "Map $SAVES/$SAVE_NAME.zip already exists, skipping map generation"
+    else
+        $SU_EXEC /opt/factorio/bin/x64/factorio \
+            --create "$SAVES/$SAVE_NAME.zip" \
+            --map-gen-settings "$CONFIG/map-gen-settings.json" \
+            --map-settings "$CONFIG/map-settings.json"
+    fi
+fi
+
+FLAGS=(\
   --port "$PORT" \
-  --start-server-load-latest \
   --server-settings "$CONFIG/server-settings.json" \
   --server-banlist "$CONFIG/server-banlist.json" \
   --rcon-port "$RCON_PORT" \
@@ -70,4 +84,13 @@ exec $SU_EXEC /opt/factorio/bin/x64/factorio \
   --server-adminlist "$CONFIG/server-adminlist.json" \
   --rcon-password "$(cat "$CONFIG/rconpw")" \
   --server-id /factorio/config/server-id.json \
-  "$@"
+)
+
+if [[ $LOAD_LATEST_SAVE == true ]]; then
+    FLAGS+=( --start-server-load-latest )
+else
+    FLAGS+=( --start-server "$SAVE_NAME" )
+fi
+
+# shellcheck disable=SC2086
+exec $SU_EXEC /opt/factorio/bin/x64/factorio "${FLAGS[@]}" "$@"

--- a/README.md
+++ b/README.md
@@ -107,6 +107,40 @@ To load an old save stop the server and run the command `touch oldsave.zip`. Thi
 
 To generate a new map stop the server, delete all of the saves and restart the server.
 
+## Specify a save directly
+
+> New in 0.17.79-2 or later
+
+You can specify a specific save to load by configuring the server through a set of environment variables:
+
+To load an existing save set `SAVE_NAME` to the name of your existing save file located within the `saves` directory, without the `.zip` extension:
+
+```
+sudo docker run -d \
+  -p 34197:34197/udp \
+  -p 27015:27015/tcp \
+  -v /opt/factorio:/factorio \
+  -e ENABLE_SERVER_LOAD_LATEST=false \
+  -e SAVE_NAME=replaceme \
+  --name factorio \
+  --restart=always \
+  factoriotools/factorio
+```
+
+To generate a new map set `ENABLE_GENERATE_NEW_MAP_SAVE=true` and specify `SAVE_NAME`:
+
+```
+sudo docker run -d \
+  -p 34197:34197/udp \
+  -p 27015:27015/tcp \
+  -v /opt/factorio:/factorio \
+  -e ENABLE_SERVER_LOAD_LATEST=false \
+  -e ENABLE_GENERATE_NEW_MAP_SAVE=true \
+  -e SAVE_NAME=replaceme \
+  --name factorio \
+  --restart=always \
+  factoriotools/factorio
+```
 
 ## Mods
 


### PR DESCRIPTION
This change enables specifying a specific save to use via the $SAVE_NAME
variable when $ENABLE_SERVER_LOAD_LATEST is false. Additionally, you can
set $ENABLE_GENERATE_NEW_MAP_SAVE to generate a map for $SAVE_NAME if
one does not already exist.

I've been using this a bit lately to swap between a few saves on my server, and
to make it easier to generate new maps by just changing my `SAVE_NAME`.

Let me know what you think.