### PR TITLE
update alpine-glibc image to 3.11

### DIFF
--- a/0.18/Dockerfile
+++ b/0.18/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-glibc:alpine-3.9
+FROM frolvlad/alpine-glibc:alpine-3.11
 
 LABEL maintainer="https://github.com/factoriotools/factorio-docker"
 


### PR DESCRIPTION
Update alpine-glibc image to 3.11 as 3.9 has not received updates for more than a year. 
Tested with my factorio installation.