### PR TITLE
Save op fix for scenario.sh and scenario2map.sh.

### DIFF
--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ox pipefail \
     && chmod ugo=rwx /opt/factorio \
     && rm "$archive" \
     && ln -s "$SCENARIOS" /opt/factorio/scenarios \
+    && ln -s "$SAVES" /opt/factorio/saves \
     && mkdir -p /opt/factorio/config/ \
     && addgroup -g "$PGID" -S "$GROUP" \
     && adduser -u "$PUID" -G "$GROUP" -s /bin/sh -SDH "$USER" \

--- a/0.18/Dockerfile
+++ b/0.18/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ox pipefail \
     && chmod ugo=rwx /opt/factorio \
     && rm "$archive" \
     && ln -s "$SCENARIOS" /opt/factorio/scenarios \
+    && ln -s "$SAVES" /opt/factorio/saves \
     && mkdir -p /opt/factorio/config/ \
     && addgroup -g "$PGID" -S "$GROUP" \
     && adduser -u "$PUID" -G "$GROUP" -s /bin/sh -SDH "$USER" \


### PR DESCRIPTION
Create symlink for save directory so that save files generated from scenario.sh/scenario2map.sh scripts will be correctly persisted in the mounted volume, instead of in /opt/factorio/saves directory which is ephemeral.