### PR TITLE
Let scenario.sh script to use map-gen-settings.json/map-settings.json located in config directory.

### DIFF
--- a/0.17/files/scenario.sh
+++ b/0.17/files/scenario.sh
@@ -32,6 +32,8 @@ fi
 exec /opt/factorio/bin/x64/factorio \
   --port "$PORT" \
   --start-server-load-scenario "$SERVER_SCENARIO" \
+  --map-gen-settings "$CONFIG/map-gen-settings.json" \
+  --map-settings "$CONFIG/map-settings.json" \
   --server-settings "$CONFIG/server-settings.json" \
   --server-banlist "$CONFIG/server-banlist.json" \
   --server-whitelist "$CONFIG/server-whitelist.json" \

--- a/0.18/files/scenario.sh
+++ b/0.18/files/scenario.sh
@@ -32,6 +32,8 @@ fi
 exec /opt/factorio/bin/x64/factorio \
   --port "$PORT" \
   --start-server-load-scenario "$SERVER_SCENARIO" \
+  --map-gen-settings "$CONFIG/map-gen-settings.json" \
+  --map-settings "$CONFIG/map-settings.json" \
   --server-settings "$CONFIG/server-settings.json" \
   --server-banlist "$CONFIG/server-banlist.json" \
   --server-whitelist "$CONFIG/server-whitelist.json" \


### PR DESCRIPTION
Let scenario.sh script to use map-gen-settings.json/map-settings.json located in config directory.

I tried the same with scenario2map.sh script, but it appears that factorio binary ignores map-gen-settings arguments when scenario2map argument is used. Therefore, only scenario.sh is updated here. (related: https://forums.factorio.com/viewtopic.php?t=69377 )

