### PR TITLE
Update docker-update-mods.sh

### DIFF
--- a/1.0/files/docker-update-mods.sh
+++ b/1.0/files/docker-update-mods.sh
@@ -5,7 +5,7 @@ if [[ -f /run/secrets/username ]]; then
   USERNAME=$(cat /run/secrets/username)
 fi
 
-if [[ -f /run/secrets/username ]]; then
+if [[ -f /run/secrets/token ]]; then
   TOKEN=$(cat /run/secrets/token)
 fi
 


### PR DESCRIPTION
Checking for /run/secrets/username to load /run/secrets/token doesn't make sense. But rather checking /run/secrets/token to load /run/secrets/token.