### PR TITLE
Remove/deprecate scenario handling entrypoints and move new scenario handling into default entry point

### DIFF
--- a/1.1/files/docker-entrypoint.sh
+++ b/1.1/files/docker-entrypoint.sh
@@ -5,6 +5,7 @@ FACTORIO_VOL=/factorio
 LOAD_LATEST_SAVE="${LOAD_LATEST_SAVE:-true}"
 GENERATE_NEW_SAVE="${GENERATE_NEW_SAVE:-false}"
 SAVE_NAME="${SAVE_NAME:-""}"
+SERVER_SCENARIO="${SERVER_SCENARIO:-""}"
 
 mkdir -p "$FACTORIO_VOL"
 mkdir -p "$SAVES"
@@ -88,11 +89,17 @@ FLAGS=(\
   --server-id /factorio/config/server-id.json \
 )
 
-if [[ $LOAD_LATEST_SAVE == true ]]; then
-    FLAGS+=( --start-server-load-latest )
-else
-    FLAGS+=( --start-server "$SAVE_NAME" )
-fi
+  if [ -z $SERVER_SCENARIO ]; then
+      if [[ $LOAD_LATEST_SAVE == true ]]; then
+          FLAGS+=( --start-server-load-latest )
+      else
+          FLAGS+=( --start-server "$SAVE_NAME" )
+      fi
+  else
+      FLAGS+=( --start-server-load-scenario "$SERVER_SCENARIO" )
+      FLAGS+=( --map-gen-settings "$CONFIG/map-gen-settings.json" )
+      FLAGS+=( --map-settings "$CONFIG/map-settings.json" )
+  fi
 
 # shellcheck disable=SC2086
 exec $SU_EXEC /opt/factorio/bin/x64/factorio "${FLAGS[@]}" "$@"

--- a/1.1/files/scenario.sh
+++ b/1.1/files/scenario.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#########
+#########
+#### senario.sh is deprecated and is subject to removal in a future release
+#########
+#########
+
 set -eoux pipefail
 
 if [[ -z ${1:-} ]]; then

--- a/1.1/files/scenario2map.sh
+++ b/1.1/files/scenario2map.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#########
+#########
+#### senario2map.sh is deprecated and is subject to removal in a future release
+#########
+#########
+
 set -eoux pipefail
 
 if [[ -z ${1:-} ]]; then

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ As of 0.17 a new environment variable was added ``UPDATE_MODS_ON_START`` which i
 
 ### Scenarios
 
-If you want to launch a scenario from a clean start (not from a saved map) you'll need to start the docker image with additional environment variables. To do this, aunch the image with the following syntax. Note that GENERATE_NEW_SAVE must be set to false, and LOAD_LATEST_SAVE must be set to false as well. SERVER_SCENARIO is the name of the Scenario in the Scenarios folder.
+If you want to launch a scenario from a clean start (not from a saved map) you'll need to start the docker image with additional environment variables. To do this, launch the image with the following syntax. Note that GENERATE_NEW_SAVE must be set to false, and LOAD_LATEST_SAVE must be set to false as well. SERVER_SCENARIO is the name of the Scenario in the Scenarios folder.
 
 ```shell
 docker run -d \

--- a/README.md
+++ b/README.md
@@ -150,34 +150,19 @@ As of 0.17 a new environment variable was added ``UPDATE_MODS_ON_START`` which i
 
 ### Scenarios
 
-If you want to launch a scenario from a clean start (not from a saved map) you'll need to start the docker image from an alternate entrypoint. To do this, use the example entrypoint file stored in the /factorio/entrypoints directory in the volume, and launch the image with the following syntax. Note that this is the normal syntax with the addition of the --entrypoint setting AND the additional argument at the end, which is the name of the Scenario in the Scenarios folder.
+If you want to launch a scenario from a clean start (not from a saved map) you'll need to start the docker image with additional environment variables. To do this, aunch the image with the following syntax. Note that GENERATE_NEW_SAVE must be set to false, and LOAD_LATEST_SAVE must be set to false as well. SERVER_SCENARIO is the name of the Scenario in the Scenarios folder.
 
 ```shell
 docker run -d \
   -p 34197:34197/udp \
   -p 27015:27015/tcp \
   -v /opt/factorio:/factorio \
+  -e LOAD_LATEST_SAVE=false \
+  -e GENERATE_NEW_SAVE=false \
+  -e SERVER_SCENARIO=MyScenario\
   --name factorio \
   --restart=always  \
-  --entrypoint "/scenario.sh" \
-  factoriotools/factorio \
-  MyScenarioName
-```
-
-### Converting Scenarios to Regular Maps
-
-If you would like to export your scenario to a saved map, you can use the example entrypoint similar to the Scenario usage above. Factorio will run once, converting the Scenario to a saved Map in your saves directory. A restart of the docker image using the standard options will then load that map, just as if the scenario were just started by the Scenarios example noted above.
-
-```shell
-docker run -d \
-  -p 34197:34197/udp \
-  -p 27015:27015/tcp \
-  -v /opt/factorio:/factorio \
-  --name factorio \
-  --restart=always  \
-  --entrypoint "/scenario2map.sh" \
   factoriotools/factorio
-  MyScenarioName
 ```
 
 ### RCON


### PR DESCRIPTION
The goal of this PR is to replace/deprecate the separate entrypoints scenario.sh and scenario2map.sh from the project due to the improper handling of map settings by this now unsupported factorio command line flag. https://forums.factorio.com/viewtopic.php?f=23&t=69377&p=422321&hilit=scenario2map#p422321

I have updated the default entry point to look for the environment variable SERVER_SCENARIO and use that as a trigger to launch that scenario without loading an existing map.

The one weakness of this is that there is no initial game save created. If the container fails without a save, progress would be lost. This is the way launching a scenario works, and there seems to be no way to have it create a save that is analogous to vanilla map creation. 