### PR TITLE
update to sha256 for checksum verification

### DIFF
--- a/1.1/Dockerfile
+++ b/1.1/Dockerfile
@@ -9,8 +9,8 @@ ARG PGID=845
 
 ENV PORT=34197 \
     RCON_PORT=27015 \
-    VERSION=1.1.38 \
-    SHA1=8adf06fd1369b84dc6afc6f927c616b5c3db23e1 \
+    VERSION=1.1.39 \
+    SHA1=d51d0d3f5cb39e2358b33486ad2b05693e4f750c \
     SAVES=/factorio/saves \
     CONFIG=/factorio/config \
     MODS=/factorio/mods \

--- a/1.1/Dockerfile
+++ b/1.1/Dockerfile
@@ -10,7 +10,7 @@ ARG PGID=845
 ENV PORT=34197 \
     RCON_PORT=27015 \
     VERSION=1.1.39 \
-    SHA1=d51d0d3f5cb39e2358b33486ad2b05693e4f750c \
+    SHA256=5528b8e23ac5d3a13e3328a0c64fee71f4a321792afe7b2fe46f95e62b7ed119 \
     SAVES=/factorio/saves \
     CONFIG=/factorio/config \
     MODS=/factorio/mods \
@@ -25,8 +25,8 @@ RUN set -ox pipefail \
     && mkdir -p /opt /factorio \
     && apk add --update --no-cache --no-progress bash binutils curl file gettext jq libintl pwgen shadow su-exec \
     && curl -sSL "https://www.factorio.com/get-download/$VERSION/headless/linux64" -o "$archive" \
-    && echo "$SHA1  $archive" | sha1sum -c \
-    || (sha1sum "$archive" && file "$archive" && exit 1) \
+    && echo "$SHA256  $archive" | sha256sum -c \
+    || (sha256sum "$archive" && file "$archive" && exit 1) \
     && tar xf "$archive" --directory /opt \
     && chmod ugo=rwx /opt/factorio \
     && rm "$archive" \


### PR DESCRIPTION
This is based on top of https://github.com/factoriotools/factorio-docker/pull/403

The second commit switches from sha1 to sha256 as the checksum verification.

## Why switch
sha1 is a smaller size so it is more susceptible to collision attacks. Since this check is only being done once during the image build, the end users will not see any difference.

- https://www.howtogeek.com/238705/what-is-sha-1-and-why-will-retiring-it-kick-thousands-off-the-internet/
- https://shattered.io/