### PR TITLE
Update dependabot to check in ./docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: docker
-  directory: "/0.18"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/0.17"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/0.16"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/0.15"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/0.14"
+  directory: "/docker"
   schedule:
     interval: daily
   open-pull-requests-limit: 10

--- a/buildinfo.json
+++ b/buildinfo.json
@@ -48,20 +48,14 @@
       "1.0"
     ]
   },
-  "1.1.38": {
-    "sha256": "e1f030a7a63be036e867c0d2d5dcb9a549788c68beccd4eb66e0bb98d44d22b1",
-    "tags": [
-      "1.1.38",
-      "stable"
-    ]
-  },
   "1.1.39": {
     "sha256": "5528b8e23ac5d3a13e3328a0c64fee71f4a321792afe7b2fe46f95e62b7ed119",
     "tags": [
       "1.1.39",
       "1",
       "1.1",
-      "latest"
+      "latest",
+      "stable"
     ]
   }
 }


### PR DESCRIPTION
~I noticed that there were open PRs for dependencies on 0.14 to 0.18 but nothing for 1.0 and 1.1.~

This is now updated to check in the ./docker directory now that there is only a single Dockerfile.
