### PR TITLE
update to sha256 for checksum verification

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install dependencies
-        run: pip install jinja2
       - name: build
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install dependencies
-        run: pip install jinja2
       - name: build
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/build.py
+++ b/build.py
@@ -7,21 +7,12 @@ import shutil
 import sys
 import tempfile
 
-from jinja2 import Environment, FileSystemLoader
-
-jinja_env = Environment(
-    loader=FileSystemLoader('templates')
-)
-
-
 def build_dockerfile(sha256, version, tags):
     build_dir = tempfile.mktemp()
     shutil.copytree("docker", build_dir)
-    template = jinja_env.get_template("Dockerfile.jinja2")
-    dockerfile_content = template.render(sha256=sha256, version=version)
-    with open(os.path.join(build_dir, "Dockerfile"), "w") as dockerfile:
-        dockerfile.write(dockerfile_content)
-    build_command = ["docker", "build", "."]
+
+    build_command = ["docker", "build", "--build-arg", f"VERSION={version}",
+                     "--build-arg", f"SHA256={sha256}", "."]
     for tag in tags:
         build_command.extend(["-t", f"factoriotools/factorio:{tag}"])
     try:

--- a/build.py
+++ b/build.py
@@ -14,11 +14,11 @@ jinja_env = Environment(
 )
 
 
-def build_dockerfile(sha1, version, tags):
+def build_dockerfile(sha256, version, tags):
     build_dir = tempfile.mktemp()
     shutil.copytree("docker", build_dir)
     template = jinja_env.get_template("Dockerfile.jinja2")
-    dockerfile_content = template.render(sha1=sha1, version=version)
+    dockerfile_content = template.render(sha256=sha256, version=version)
     with open(os.path.join(build_dir, "Dockerfile"), "w") as dockerfile:
         dockerfile.write(dockerfile_content)
     build_command = ["docker", "build", "."]
@@ -52,9 +52,9 @@ def main(push_tags=False):
         login()
 
     for version, buildinfo in builddata.items():
-        sha1 = buildinfo["sha1"]
+        sha256 = buildinfo["sha256"]
         tags = buildinfo["tags"]
-        build_dockerfile(sha1, version, tags)
+        build_dockerfile(sha256, version, tags)
         if not push_tags:
             continue
         for tag in tags:

--- a/buildinfo.json
+++ b/buildinfo.json
@@ -1,62 +1,62 @@
 {
   "0.12.35": {
-    "sha1": "ea15636469148662c26786ad916ac066ee5aab56",
+    "sha256": "ab9cf01a56dde3073aaaa5152c628bbf9a5bb85638b87dc3d7fdb77fb169aedd",
     "tags": [
       "0.12.35",
       "0.12"
     ]
   },
   "0.13.20": {
-    "sha1": "59ed0edb3f62f0f41a01fc291959b0a8b44cf631",
+    "sha256": "cbf5481e4b7e0efcc07c7b6a1fc3ff1404ad5597f3c9d37914a52ffb58d7c159",
     "tags": [
       "0.13.20",
       "0.13"
     ]
   },
   "0.14.23": {
-    "sha1": "6ef84341c6fc1cf45cfdd6acc8468aaa117b9e8a",
+    "sha256": "96c3e7acd4e0f066a499baba01823cac7c1caf0e50dbddcea5793f57bd60dc8c",
     "tags": [
       "0.14.23",
       "0.14"
     ]
   },
   "0.15.40": {
-    "sha1": "f79a975f6b8c0ee87e2fa60f7d1f7133f332c3ec",
+    "sha256": "1041ef61ea4aecd1f425e6030a909f0c349a9c01d1b3324d84a61b1cfef5ba6c",
     "tags": [
       "0.15.40",
       "0.15"
     ]
   },
   "0.16.51": {
-    "sha1": "127e7ff484ab263b13615d6114013ce0a66ac929",
+    "sha256": "6cb09f5ac87f16f8d5b43cef26c0ae26cc46a57a0382e253dfda032dc5bb367f",
     "tags": [
       "0.16.51",
       "0.16"
     ]
   },
   "0.17.79": {
-    "sha1": "7f127baf3cf01c6e545a9ca376dec1ac37468f8a",
+    "sha256": "9ace12fa986df028dc1851bf4de2cb038044d743e98823bc1c48ba21aa4d23df",
     "tags": [
       "0.17.79",
       "0.17"
     ]
   },
   "1.0.0": {
-    "sha1": "a50dd6f1ab17acde5a8d77bc5fb478c798d9c20e",
+    "sha256": "81d9e1aa94435aeec4131c8869fa6e9331726bea1ea31db750b65ba42dbd1464",
     "tags": [
       "1.0.0",
       "1.0"
     ]
   },
   "1.1.38": {
-    "sha1": "8adf06fd1369b84dc6afc6f927c616b5c3db23e1",
+    "sha256": "e1f030a7a63be036e867c0d2d5dcb9a549788c68beccd4eb66e0bb98d44d22b1",
     "tags": [
       "1.1.38",
       "stable"
     ]
   },
   "1.1.39": {
-    "sha1": "d51d0d3f5cb39e2358b33486ad2b05693e4f750c",
+    "sha256": "5528b8e23ac5d3a13e3328a0c64fee71f4a321792afe7b2fe46f95e62b7ed119",
     "tags": [
       "1.1.39",
       "1",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,10 +7,14 @@ ARG GROUP=factorio
 ARG PUID=845
 ARG PGID=845
 
+# version checksum of the archive to download
+ARG VERSION
+ARG SHA256
+
 ENV PORT=34197 \
     RCON_PORT=27015 \
-    VERSION={{ version }} \
-    SHA256={{ sha256 }} \
+    VERSION=${VERSION:?} \
+    SHA256=${SHA256:?} \
     SAVES=/factorio/saves \
     CONFIG=/factorio/config \
     MODS=/factorio/mods \

--- a/templates/Dockerfile.jinja2
+++ b/templates/Dockerfile.jinja2
@@ -10,7 +10,7 @@ ARG PGID=845
 ENV PORT=34197 \
     RCON_PORT=27015 \
     VERSION={{ version }} \
-    SHA1={{ sha1 }} \
+    SHA256={{ sha256 }} \
     SAVES=/factorio/saves \
     CONFIG=/factorio/config \
     MODS=/factorio/mods \
@@ -25,8 +25,8 @@ RUN set -ox pipefail \
     && mkdir -p /opt /factorio \
     && apk add --update --no-cache --no-progress bash binutils curl file gettext jq libintl pwgen shadow su-exec \
     && curl -sSL "https://www.factorio.com/get-download/$VERSION/headless/linux64" -o "$archive" \
-    && echo "$SHA1  $archive" | sha1sum -c \
-    || (sha1sum "$archive" && file "$archive" && exit 1) \
+    && echo "$SHA256  $archive" | sha256sum -c \
+    || (sha256sum "$archive" && file "$archive" && exit 1) \
     && tar xf "$archive" --directory /opt \
     && chmod ugo=rwx /opt/factorio \
     && rm "$archive" \


### PR DESCRIPTION
This is a rework of #404 which switches from sha1 to sha256.

This also drops the usage of the jinja templating in favour of the docker build-args.
- https://github.com/factoriotools/factorio-docker/pull/382#issuecomment-911659518