### PR TITLE
Add ARM template for Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,9 @@ For LAN games the VM needs an internal IP in order for clients to connect. One w
 
 If you're looking for a simple way to deploy this to the Amazon Web Services Cloud, check out the [Factorio Server Deployment (CloudFormation) repository](https://github.com/m-chandler/factorio-spot-pricing). This repository contains a CloudFormation template that will get you up and running in AWS in a matter of minutes. Optionally it uses Spot Pricing so the server is very cheap, and you can easily turn it off when not in use.
 
+### Azure
+If you are looking for a simple way to deploy this to Azure, check out the config file under: [configs/Azure](configs/Azure/README.md). This contains a simple guide and ARM template to host the container out on Azure Container Instances.
+
 ## Troubleshooting
 
 ### My server is listed in the server browser, but nobody can connect

--- a/configs/Azure/CreateContainer.json
+++ b/configs/Azure/CreateContainer.json
@@ -1,0 +1,135 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "dnsPrefix": {
+            "defaultValue": "<uniquePrefix>",
+            "type": "string"
+        },
+        "containerGroupsName": {
+            "defaultValue": "factorio",
+            "type": "string"
+        },
+        "storageAccountName": {
+            "type": "string",
+            "defaultValue": "factorio"
+        },
+        "storageAccountType": {
+            "type": "string",
+            "defaultValue": "Standard_LRS",
+            "allowedValues": [
+                "Standard_LRS",
+                "Standard_GRS",
+                "Standard_ZRS"
+            ],
+            "metadata": {
+                "description": "Storage account for game"
+            }
+        }
+    },
+    "variables": {
+        "fileShareName": "factorio",
+        "cpuCores": 2,
+        "memoryInGb": 4
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "2021-04-01",
+            "name": "[parameters('storageAccountName')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "[parameters('storageAccountType')]",
+                "tier": "Standard"
+            },
+            "kind": "StorageV2",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "apiVersion": "2019-04-01",
+            "name": "[concat(parameters('storageAccountName'), '/default/', variables('fileShareName'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+            ]
+        },  
+        {
+            "type": "Microsoft.ContainerInstance/containerGroups",
+            "apiVersion": "2021-03-01",
+            "name": "[parameters('containerGroupsName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "sku": "Standard",
+                "containers": [
+                    {
+                        "name": "[parameters('containerGroupsName')]",
+                        "properties": {
+                            "image": "factoriotools/factorio:stable",
+                            "command": [ ],
+                            "ports": [
+                                {
+                                    "protocol": "UDP",
+                                    "port": 34197
+                                },
+                                {
+                                    "protocol": "TCP",
+                                    "port": 27015
+                                }
+                            ],
+                            "environmentVariables": [],
+                            "resources": {
+                                "requests": {
+                                    "cpu": "[variables('cpuCores')]",
+                                    "memoryInGB": "[variables('memoryInGb')]"
+                                }
+                            },
+                            "volumeMounts": [
+                                {
+                                    "name": "data",
+                                    "readOnly": false,
+                                    "mountPath": "/factorio"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "initContainers": [],
+                "restartPolicy": "OnFailure",
+                "ipAddress": {
+                    "ports": [
+                        {
+                            "protocol": "UDP",
+                            "port": 34197
+                        },
+                        {
+                            "protocol": "TCP",
+                            "port": 27015
+                        }
+                    ],
+                    "ip": "20.81.71.43",
+                    "type": "Public",
+                    "dnsNameLabel": "[concat(parameters('dnsPrefix'), '-', parameters('containerGroupsName'))]"
+                },
+                "osType": "Linux",
+                "volumes": [
+                    {
+                      "name": "data",
+                      "azureFile": {
+                          "readOnly": false,
+                          "shareName": "[variables('fileShareName')]",
+                          "storageAccountName": "[parameters('storageAccountName')]",
+                          "storageAccountKey": "[listKeys(parameters('storageAccountName'),'2021-04-01').keys[0].value]"
+                      }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/configs/Azure/README.md
+++ b/configs/Azure/README.md
@@ -1,0 +1,33 @@
+
+# Create a resource group to associate the container with
+To create Azure resources they must be associated with a resource group. You can create a new resource group with the following:
+
+`az group create --name GameResources --location eastus`
+
+where `GameResources` is the name of the resource group and `eastus` is the Azure location you want the resources associated with. You can modify either of these to your needs.
+
+# Create the container and storage account for the resource group
+Customize CreateContainer.json, specifically the following:
+- dnsPrefix.defaultValue: This is a unique prefix to give to your dns address which will be used to connect to your container. The final form will be `dnsPrefix-factorio.eastus.azurecontainer.io` assuming your resource group is in the eastus location.
+- variables.cpuCores: The number of cores for the container
+- variables.memoryInGb: The memory of the container
+
+Then run the following command which will create the storage account (unless it already exists) and container instance
+
+`az deployment group create --resource-group GameResources --template-file CreateContainer.json`
+
+# Customizing settings
+After you have created the container, it will initialize all of its configuration in the storage account which can be accessed through the [Azure Portal](https://portal.azure.com/). After customizing the settings restart the container with:
+
+`az container restart --resource-group GameResources --name factorio`
+
+where `GameResouces` is your resource group and `factorio` is the name of your container group.
+
+# Updating the container
+Since all of the game data is persisted in the storage account, updating the container is just deleting and creating it again. This can be done with:
+
+`az container delete --resource-group GameResources --name factorio`
+
+`az deployment group create --resource-group GameResources --template-file CreateContainer.json`
+
+where `GameResouces` is your resource group and `factorio` is the name of your container group.


### PR DESCRIPTION
- Add ARM template for hosting container on Azure Container Instances
with data persisted to an Azure Storage Account.
- Add README for Azure ARM template and link from main README.