### PR TITLE
support older versions of docker and docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,16 +304,19 @@ The files in this volume should be owned by the factorio user, uid 845.
 
 [Docker Compose](https://docs.docker.com/compose/install/) is an easy way to run Docker containers.
 
-First get a [docker-compose.yml](https://github.com/factoriotools/factorio-docker/blob/master/0.17/docker-compose.yml) file. To get it from this repository:
+* docker-engine >= 1.10.0 is required
+* docker-compose >=1.6.0 is required
+
+First get a [docker-compose.yml](https://github.com/factoriotools/factorio-docker/blob/master/docker/docker-compose.yml) file. To get it from this repository:
 
 ```shell
 git clone https://github.com/factoriotools/factorio-docker.git
-cd docker_factorio_server/0.17
+cd factorio-docker/docker
 ```
 
 Or make your own:
 
-```shell
+```yaml
 version: '2'
 services:
   factorio:
@@ -342,7 +345,7 @@ sudo docker-compose up -d
 
 Ensure the `lan` setting in server-settings.json is `true`.
 
-```shell
+```json
   "visibility":
   {
     "public": false,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,8 @@ ARG SHA256
 
 ENV PORT=34197 \
     RCON_PORT=27015 \
-    VERSION=${VERSION:?} \
-    SHA256=${SHA256:?} \
+    VERSION=${VERSION} \
+    SHA256=${SHA256} \
     SAVES=/factorio/saves \
     CONFIG=/factorio/config \
     MODS=/factorio/mods \
@@ -25,6 +25,14 @@ ENV PORT=34197 \
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN set -ox pipefail \
+    && if [[ "${VERSION}" == "" ]]; then \
+        echo "build-arg VERSION is required" \
+        && exit 1; \
+    fi \
+    && if [[ "${SHA256}" == "" ]]; then \
+        echo "build-arg SHA256 is required" \
+        && exit 1; \
+    fi \
     && archive="/tmp/factorio_headless_x64_$VERSION.tar.xz" \
     && mkdir -p /opt /factorio \
     && apk add --update --no-cache --no-progress bash binutils curl file gettext jq libintl pwgen shadow su-exec \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,13 @@
 version: '2'
 services:
   factorio:
-    build: .
+    build:
+      context: .
+      args:
+      # Check buildinfo.json for supported versions and SHAs
+      # https://github.com/factoriotools/factorio-docker/blob/master/buildinfo.json
+      - VERSION=1.1.39
+      - SHA256=5528b8e23ac5d3a13e3328a0c64fee71f4a321792afe7b2fe46f95e62b7ed119
     ports:
      - "34197:34197/udp"
      - "27015:27015/tcp"


### PR DESCRIPTION
Related: https://github.com/factoriotools/factorio-docker/issues/412

This should fix the issue where some people are seeing this error message when using a docker compose setup.
```
 ERROR: Service 'factorio' failed to build: failed to process "${VERSION:?}": unsupported modifier (?) in substitution
```

I could not find the exact version where docker changed or added support for the variable substitution, so the next best thing was to not use it and add in a check for the value.

I did find that docker-compose >= 1.6.0 is needed because this project is using v2 of the compose spec
- https://github.com/docker/compose/releases/tag/1.6.0

The other option I see here is to have buildinfo.json added into the container and then have the docker file determine which version to install when `VERSION` is unset.
If we want to go down that route, Id suggest doing that as a follow up PR so that this unblocks users from using docker-compose and having it build the image.