### PR TITLE
Skip pushing to docker hub when user and pass are not specified

### DIFF
--- a/.github/workflows/docker-description.yml
+++ b/.github/workflows/docker-description.yml
@@ -1,4 +1,4 @@
-name: Docker build & push
+name: Docker Hub Description
 
 on:
   push:
@@ -13,6 +13,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v2.4.1
+        if: ${{ env.DOCKER_USERNAME != '' && env.DOCKER_PASSWORD != '' }}
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: build
+      - name: build and push
+        if: ${{ env.DOCKER_USERNAME != '' && env.DOCKER_PASSWORD != '' }}
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
When I have been syncing my fork I noticed that the GitHub actions were running on the master branch and failing.
This changes the workflows so that it will only try pushing if the secrets are specified.

You can see some example flows here where I was forcing it to run on any push for testing
- https://github.com/perobertson/factorio-docker/actions

Ideally I would use `jobs.<job_id>.if` to specify the condition, but I could not find a way to see if the secrets were available.
The next best thing was to use `jobs.<job_id>.steps.if` and check if an environment was available.
- https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability