### PR TITLE
Update to 1.1.41 in docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       args:
       # Check buildinfo.json for supported versions and SHAs
       # https://github.com/factoriotools/factorio-docker/blob/master/buildinfo.json
-      - VERSION=1.1.39
-      - SHA256=5528b8e23ac5d3a13e3328a0c64fee71f4a321792afe7b2fe46f95e62b7ed119
+      - VERSION=1.1.41
+      - SHA256=824cd413ed056e4a28dbce76f743961d42e5aef87b385e27a9c57f1e924a9a5e
     ports:
      - "34197:34197/udp"
      - "27015:27015/tcp"


### PR DESCRIPTION
Bumps version and SHA256 to latest version.