### PR TITLE
fix entrypoint logic for checking if root

### DIFF
--- a/docker/files/docker-entrypoint.sh
+++ b/docker/files/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [[ ${UPDATE_MODS_ON_START:-} == "true" ]]; then
   ./docker-update-mods.sh
 fi
 
-if [[ $(id -u) = 0 ]]; then
+if [[ $(id -u) == 0 ]]; then
   # Update the User and Group ID based on the PUID/PGID variables
   usermod -o -u "$PUID" factorio
   groupmod -o -g "$PGID" factorio


### PR DESCRIPTION
Ran into this bug trying to use configMaps to populate the configs in a kubernetes deployment. The missing equals sign leads to an unnecessary attempt to change ownership on otherwise read-only files.