### PR TITLE
Update Dockerfile - add curl retries (#444)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,9 @@ ARG PGID=845
 ARG VERSION
 ARG SHA256
 
+# number of retries that curl will use when pulling the headless server tarball
+ARG CURL_RETRIES=8
+
 ENV PORT=34197 \
     RCON_PORT=27015 \
     VERSION=${VERSION} \
@@ -36,7 +39,7 @@ RUN set -ox pipefail \
     && archive="/tmp/factorio_headless_x64_$VERSION.tar.xz" \
     && mkdir -p /opt /factorio \
     && apk add --update --no-cache --no-progress bash binutils curl file gettext jq libintl pwgen shadow su-exec \
-    && curl -sSL "https://www.factorio.com/get-download/$VERSION/headless/linux64" -o "$archive" \
+    && curl -sSL "https://www.factorio.com/get-download/$VERSION/headless/linux64" -o "$archive" --retry $CURL_RETRIES\
     && echo "$SHA256  $archive" | sha256sum -c \
     || (sha256sum "$archive" && file "$archive" && exit 1) \
     && tar xf "$archive" --directory /opt \


### PR DESCRIPTION
Adding configurable retries to the curl download of the headless server tarball.