### PR TITLE
Add an IP bind param to the entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ These are the environment variables which can be specified at container run time
 | GENERATE_NEW_SAVE | Generate a new save if one does not exist before starting the server  | false | 0.17+ |
 | LOAD_LATEST_SAVE | Load latest when true. Otherwise load SAVE_NAME | true | 0.17+ |
 | PORT | UDP port the server listens on | 34197 | 0.15+ |
-| ADDR | IP address (v4 or v6) the server listens on | | 0.15+ |
+| BIND | IP address (v4 or v6) the server listens on (IP\[:PORT]) | | 0.15+ |
 | RCON_PORT | TCP port the rcon server listens on | 27015 | 0.15+ |
 | SAVE_NAME | Name to use for the save file | _autosave1 | 0.17+ |
 | TOKEN | factorio.com token | | 0.17+ |
@@ -397,7 +397,7 @@ stream {
 }
 ```
 
-If your factorio host uses multiple IP addresses (very common with IPv6), you might additionally need to bind Factorio to a single IP (otherwise the UDP proxy might get confused with IP mismatches). To do that pass the `ADDR` envvar to the container: `docker run --network=host -e ADDR=2a02:1234::5678 ...`
+If your factorio host uses multiple IP addresses (very common with IPv6), you might additionally need to bind Factorio to a single IP (otherwise the UDP proxy might get confused with IP mismatches). To do that pass the `BIND` envvar to the container: `docker run --network=host -e BIND=2a02:1234::5678 ...`
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,21 @@ For LAN games the VM needs an internal IP in order for clients to connect. One w
 
 If you're looking for a simple way to deploy this to the Amazon Web Services Cloud, check out the [Factorio Server Deployment (CloudFormation) repository](https://github.com/m-chandler/factorio-spot-pricing). This repository contains a CloudFormation template that will get you up and running in AWS in a matter of minutes. Optionally it uses Spot Pricing so the server is very cheap, and you can easily turn it off when not in use.
 
+## Using a reverse proxy
+
+If you need to use a reverse proxy you can use the following nginx snippet:
+
+```
+stream {
+  server {
+      listen 34197 udp reuseport;
+      proxy_pass my.upstream.host:34197;
+  }
+}
+```
+
+If your factorio host uses multiple IP addresses (very common with IPv6), you might additionally need to bind Factorio to a single IP (otherwise the UDP proxy might get confused with IP mismatches). To do that pass the `ADDR` envvar to the container: `docker run --network=host -e ADDR=2a02:1234::5678 ...`
+
 ## Troubleshooting
 
 ### My server is listed in the server browser, but nobody can connect

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ These are the environment variables which can be specified at container run time
 | GENERATE_NEW_SAVE | Generate a new save if one does not exist before starting the server  | false | 0.17+ |
 | LOAD_LATEST_SAVE | Load latest when true. Otherwise load SAVE_NAME | true | 0.17+ |
 | PORT | UDP port the server listens on | 34197 | 0.15+ |
+| ADDR | IP address (v4 or v6) the server listens on | | 0.15+ |
 | RCON_PORT | TCP port the rcon server listens on | 27015 | 0.15+ |
 | SAVE_NAME | Name to use for the save file | _autosave1 | 0.17+ |
 | TOKEN | factorio.com token | | 0.17+ |

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,3 +20,4 @@ services:
 #      - USERNAME=FactorioUsername
 #      - TOKEN=FactorioToken
 #      - PORT=34198
+#      - ADDR=::1

--- a/docker/files/docker-entrypoint.sh
+++ b/docker/files/docker-entrypoint.sh
@@ -5,6 +5,7 @@ FACTORIO_VOL=/factorio
 LOAD_LATEST_SAVE="${LOAD_LATEST_SAVE:-true}"
 GENERATE_NEW_SAVE="${GENERATE_NEW_SAVE:-false}"
 SAVE_NAME="${SAVE_NAME:-""}"
+ADDR="${ADDR:-""}"
 
 mkdir -p "$FACTORIO_VOL"
 mkdir -p "$SAVES"
@@ -87,6 +88,10 @@ FLAGS=(\
   --rcon-password "$(cat "$CONFIG/rconpw")" \
   --server-id /factorio/config/server-id.json \
 )
+
+if [ -n "$ADDR" ]; then
+  FLAGS+=( --bind "$ADDR" )
+fi
 
 if [[ $LOAD_LATEST_SAVE == true ]]; then
     FLAGS+=( --start-server-load-latest )

--- a/docker/files/docker-entrypoint.sh
+++ b/docker/files/docker-entrypoint.sh
@@ -5,7 +5,7 @@ FACTORIO_VOL=/factorio
 LOAD_LATEST_SAVE="${LOAD_LATEST_SAVE:-true}"
 GENERATE_NEW_SAVE="${GENERATE_NEW_SAVE:-false}"
 SAVE_NAME="${SAVE_NAME:-""}"
-ADDR="${ADDR:-""}"
+BIND="${BIND:-""}"
 
 mkdir -p "$FACTORIO_VOL"
 mkdir -p "$SAVES"
@@ -89,8 +89,8 @@ FLAGS=(\
   --server-id /factorio/config/server-id.json \
 )
 
-if [ -n "$ADDR" ]; then
-  FLAGS+=( --bind "$ADDR" )
+if [ -n "$BIND" ]; then
+  FLAGS+=( --bind "$BIND" )
 fi
 
 if [[ $LOAD_LATEST_SAVE == true ]]; then


### PR DESCRIPTION
Factorio allows setting an IP address to bind to in the `--bind` switch.
The current configuration allows setting the port, this PR also allows setting the IP using the `ADDR` envvar.

The behavior is as expected, setting `--port 1000 --bind ::1` will bind Factorio to `::1:1000`.


### Why?

For example it allows restricting the IPv6 address used in server responses to allow UDP reverse proxies to work. Without such restriction the proxy may fail to recognize upstream responses due to a different IP being used for response.