### PR TITLE
Add --console-log support

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ These are the environment variables which can be specified at container run time
 | TOKEN | factorio.com token | | 0.17+ |
 | UPDATE_MODS_ON_START | If mods should be updated before starting the server | | 0.17+ |
 | USERNAME | factorio.com username | | 0.17+ | |
+| CONSOLE_LOG_LOCATION | Saves the console log to the specifies location | |
 
 **Note:** All environment variables are compared as strings
 

--- a/docker/files/docker-entrypoint.sh
+++ b/docker/files/docker-entrypoint.sh
@@ -6,6 +6,7 @@ LOAD_LATEST_SAVE="${LOAD_LATEST_SAVE:-true}"
 GENERATE_NEW_SAVE="${GENERATE_NEW_SAVE:-false}"
 SAVE_NAME="${SAVE_NAME:-""}"
 BIND="${BIND:-""}"
+CONSOLE_LOG_LOCATION="${CONSOLE_LOG_LOCATION:-""}"
 
 mkdir -p "$FACTORIO_VOL"
 mkdir -p "$SAVES"
@@ -88,6 +89,10 @@ FLAGS=(\
   --rcon-password "$(cat "$CONFIG/rconpw")" \
   --server-id /factorio/config/server-id.json \
 )
+
+if [ -n "$CONSOLE_LOG_LOCATION" ]; then
+  FLAGS+=( --console-log "$CONSOLE_LOG_LOCATION" )
+fi
 
 if [ -n "$BIND" ]; then
   FLAGS+=( --bind "$BIND" )


### PR DESCRIPTION
Fixes https://github.com/factoriotools/factorio-docker/issues/460

I don't know when that argument has been introduced, that's why the `Available In` section is currently blank