### PR TITLE
Use official sha256 endpoint for update check

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -4,8 +4,8 @@ SEMVER_REGEX="^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
 
 stable_online_version=$(curl 'https://factorio.com/api/latest-releases' | jq '.stable.headless' -r)
 experimental_online_version=$(curl 'https://factorio.com/api/latest-releases' | jq '.experimental.headless' -r)
-stable_sha256=$(curl "https://www.factorio.com/get-download/${stable_online_version}/headless/linux64" -L | sha256sum | awk '{print $1}')
-experimental_sha256=$(curl "https://www.factorio.com/get-download/${experimental_online_version}/headless/linux64" -L | sha256sum | awk '{print $1}')
+stable_sha256=$(curl "https://factorio.com/download/sha256sums/" | grep "factorio_headless_x64_${stable_online_version}.tar.xz" | awk '{print $1}')
+experimental_sha256=$(curl "https://factorio.com/download/sha256sums/" | grep "factorio_headless_x64_${experimental_online_version}.tar.xz" | awk '{print $1}')
 stable_current_version=$(jq 'with_entries(select(contains({value:{tags:["stable"]}}))) | keys | .[0]' buildinfo.json -r)
 latest_current_version=$(jq 'with_entries(select(contains({value:{tags:["latest"]}}))) | keys | .[0]' buildinfo.json -r)
 echo "stable_online_version=${stable_online_version} experimental_online_version=${experimental_online_version}"


### PR DESCRIPTION
Hey there, we're publishing the official sha256sum on factorio.com, so downloading the latest release from our CDN is not necessary.