### PR TITLE
Container label for factorio version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,8 @@ ARG BOX64_VERSION=v0.2.4
 ARG VERSION
 ARG SHA256
 
+LABEL factorio.version=${VERSION}
+
 # number of retries that curl will use when pulling the headless server tarball
 ARG CURL_RETRIES=8
 


### PR DESCRIPTION
Having a label on the factorio container which stores the factorio version of the container is useful for automation and debugging purposes. Furthermore it is a simple addition to the dockerfile.