### PR TITLE
Improve image stages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,19 +16,11 @@ ARG BOX64_VERSION=v0.2.4
 # space-exploration
 ARG PRESET
 
-# version checksum of the archive to download
-ARG VERSION
-ARG SHA256
-
-LABEL factorio.version=${VERSION}
-
 # number of retries that curl will use when pulling the headless server tarball
 ARG CURL_RETRIES=8
 
 ENV PORT=34197 \
     RCON_PORT=27015 \
-    VERSION=${VERSION} \
-    SHA256=${SHA256} \
     SAVES=/factorio/saves \
     PRESET="$PRESET" \
     CONFIG=/factorio/config \
@@ -39,6 +31,31 @@ ENV PORT=34197 \
     PGID="$PGID"
 
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+RUN apt-get -q update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qy install ca-certificates curl jq pwgen xz-utils procps gettext-base --no-install-recommends \
+    && if [[ "$(uname -m)" == "aarch64" ]]; then \
+        echo "installing ARM compatability layer" \
+        && DEBIAN_FRONTEND=noninteractive apt-get -qy install unzip --no-install-recommends \ 
+        && curl -LO https://github.com/ptitSeb/box64/releases/download/${BOX64_VERSION}/box64-GENERIC_ARM-RelWithDebInfo.zip \
+        && unzip box64-GENERIC_ARM-RelWithDebInfo.zip -d /bin \
+        && rm -f box64-GENERIC_ARM-RelWithDebInfo.zip \
+        && chmod +x /bin/box64; \
+    fi \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN addgroup --system --gid "$PGID" "$GROUP" \
+    && adduser --system --uid "$PUID" --gid "$PGID" --no-create-home --disabled-password --shell /bin/sh "$USER"
+
+# version checksum of the archive to download
+ARG VERSION
+ARG SHA256
+
+LABEL factorio.version=${VERSION}
+
+ENV VERSION=${VERSION} \
+    SHA256=${SHA256}
+
 RUN set -ox pipefail \
     && if [[ "${VERSION}" == "" ]]; then \
         echo "build-arg VERSION is required" \
@@ -50,28 +67,15 @@ RUN set -ox pipefail \
     fi \
     && archive="/tmp/factorio_headless_x64_$VERSION.tar.xz" \
     && mkdir -p /opt /factorio \
-    && apt-get -q update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -qy install ca-certificates curl jq pwgen xz-utils procps gettext-base --no-install-recommends \
-    && curl -sSL "https://www.factorio.com/get-download/$VERSION/headless/linux64" -o "$archive" --retry $CURL_RETRIES\
+    && curl -sSL "https://www.factorio.com/get-download/$VERSION/headless/linux64" -o "$archive" --retry $CURL_RETRIES \
     && echo "$SHA256  $archive" | sha256sum -c \
     || (sha256sum "$archive" && file "$archive" && exit 1) \
     && tar xf "$archive" --directory /opt \
     && chmod ugo=rwx /opt/factorio \
     && rm "$archive" \
-    && if [[ "$(uname -m)" == "aarch64" ]]; then \
-        echo "installing ARM compatability layer" \
-        && DEBIAN_FRONTEND=noninteractive apt-get -qy install unzip --no-install-recommends \ 
-        && curl -LO https://github.com/ptitSeb/box64/releases/download/${BOX64_VERSION}/box64-GENERIC_ARM-RelWithDebInfo.zip \
-        && unzip box64-GENERIC_ARM-RelWithDebInfo.zip -d /bin \
-        && rm -f box64-GENERIC_ARM-RelWithDebInfo.zip \
-        && chmod +x /bin/box64; \
-    fi \
-    && rm -rf /var/lib/apt/lists/* \
     && ln -s "$SCENARIOS" /opt/factorio/scenarios \
     && ln -s "$SAVES" /opt/factorio/saves \
     && mkdir -p /opt/factorio/config/ \
-    && addgroup --system --gid "$PGID" "$GROUP" \
-    && adduser --system --uid "$PUID" --gid "$PGID" --no-create-home --disabled-password --shell /bin/sh "$USER" \
     && chown -R "$USER":"$GROUP" /opt/factorio /factorio
 
 COPY files/*.sh /


### PR DESCRIPTION
As discussed in #506, this change re-uses intermediate stages for apt update, apt install and box64 install, and subsequent clean-up.

The docker image size stays the same, but the build is faster as the operations mentioned above are re-used for all images.