### PR TITLE
Added DLC_SPACE_AGE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ These are the environment variables which can be specified at container run time
 | UPDATE_MODS_ON_START | If mods should be updated before starting the server                 |            | 0.17+        |
 | USERNAME             | factorio.com username                                                |            | 0.17+        |
 | CONSOLE_LOG_LOCATION | Saves the console log to the specifies location                      |            |              |
-| DLC_SPACE_AGE        | Enables or disables the dlc mod-list.json                            | true       | 2.0.8+       |
+| DLC_SPACE_AGE        | Enables or disables the mods for DLC Space Age in mod-list.json      | true       | 2.0.8+       |
 
 **Note:** All environment variables are compared as strings
 

--- a/README.md
+++ b/README.md
@@ -260,18 +260,19 @@ The `server-settings.json` file may then contain the variable references like th
 
 These are the environment variables which can be specified at container run time.
 
-| Variable Name | Description | Default | Available in |
-| - | - | - | - |
-| GENERATE_NEW_SAVE | Generate a new save if one does not exist before starting the server  | false | 0.17+ |
-| LOAD_LATEST_SAVE | Load latest when true. Otherwise load SAVE_NAME | true | 0.17+ |
-| PORT | UDP port the server listens on | 34197 | 0.15+ |
-| BIND | IP address (v4 or v6) the server listens on (IP\[:PORT]) | | 0.15+ |
-| RCON_PORT | TCP port the rcon server listens on | 27015 | 0.15+ |
-| SAVE_NAME | Name to use for the save file | _autosave1 | 0.17+ |
-| TOKEN | factorio.com token | | 0.17+ |
-| UPDATE_MODS_ON_START | If mods should be updated before starting the server | | 0.17+ |
-| USERNAME | factorio.com username | | 0.17+ | |
-| CONSOLE_LOG_LOCATION | Saves the console log to the specifies location | |
+| Variable Name        | Description                                                          | Default    | Available in |
+|----------------------|----------------------------------------------------------------------|------------|--------------|
+| GENERATE_NEW_SAVE    | Generate a new save if one does not exist before starting the server | false      | 0.17+        |
+| LOAD_LATEST_SAVE     | Load latest when true. Otherwise load SAVE_NAME                      | true       | 0.17+        |
+| PORT                 | UDP port the server listens on                                       | 34197      | 0.15+        |
+| BIND                 | IP address (v4 or v6) the server listens on (IP\[:PORT])             |            | 0.15+        |
+| RCON_PORT            | TCP port the rcon server listens on                                  | 27015      | 0.15+        |
+| SAVE_NAME            | Name to use for the save file                                        | _autosave1 | 0.17+        |
+| TOKEN                | factorio.com token                                                   |            | 0.17+        |
+| UPDATE_MODS_ON_START | If mods should be updated before starting the server                 |            | 0.17+        |
+| USERNAME             | factorio.com username                                                |            | 0.17+        |
+| CONSOLE_LOG_LOCATION | Saves the console log to the specifies location                      |            |              |
+| DLC_SPACE_AGE        | Enables or disables the dlc mod-list.json                            | true       | 2.0.8+       |
 
 **Note:** All environment variables are compared as strings
 

--- a/docker/files/docker-dlc.sh
+++ b/docker/files/docker-dlc.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -eou pipefail
+
+# Path to the mod-list.json file
+MOD_LIST_FILE="$MODS/mod-list.json"
+
+enable_mod()
+{
+  echo "Enable mod $1 for DLC"
+  jq --arg mod_name "$1" 'if .mods | map(.name) | index($mod_name) then .mods |= map(if .name == $mod_name and .enabled == false then .enabled = true else . end) else . end' "$MOD_LIST_FILE" > "$MOD_LIST_FILE.tmp"
+  mv "$MOD_LIST_FILE.tmp" "$MOD_LIST_FILE"
+}
+
+disable_mod()
+{
+  echo "Disable mod $1 for DLC"
+  jq --arg mod_name "$1" 'if .mods | map(.name) | index($mod_name) then .mods |= map(if .name == $mod_name and .enabled == true then .enabled = false else . end) else .mods += [{"name": $mod_name, "enabled": false}] end' "$MOD_LIST_FILE" > "$MOD_LIST_FILE.tmp"
+  mv "$MOD_LIST_FILE.tmp" "$MOD_LIST_FILE"
+}
+
+# Enable or disable DLCs if configured
+if [[ ${DLC_SPACE_AGE:-} == "true" ]]; then
+  # Define the DLC mods
+  DLC_MODS=("elevated-rails" "quality" "space-age")
+
+  # Iterate over each DLC mod
+  for MOD in "${DLC_MODS[@]}"; do
+    enable_mod "$MOD"
+  done
+else
+  # Define the DLC mods
+  DLC_MODS=("elevated-rails" "quality" "space-age")
+
+  # Iterate over each DLC mod
+  for MOD in "${DLC_MODS[@]}"; do
+    disable_mod "$MOD"
+  done
+fi

--- a/docker/files/docker-entrypoint.sh
+++ b/docker/files/docker-entrypoint.sh
@@ -43,6 +43,8 @@ if [[ ${UPDATE_MODS_ON_START:-} == "true" ]]; then
   ./docker-update-mods.sh
 fi
 
+./docker-dlc.sh
+
 EXEC=""
 if [[ $(id -u) = 0 ]]; then
   # Update the User and Group ID based on the PUID/PGID variables


### PR DESCRIPTION
This pull request includes updates to the `README.md` file for better formatting and the addition of a new environment variable, as well as new scripts to manage DLC mods in the Docker setup.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L264-R264): Improved table formatting for environment variables and added a new variable `DLC_SPACE_AGE` to enable or disable DLC mods. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L264-R264) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L273-R275)

### Docker Script Enhancements:

* [`docker/files/docker-dlc.sh`](diffhunk://#diff-1d00cf54e20862293ddcb244a1557d9bb2a2b77e92eca21161323c51944c3605R1-R38): Added a new script to enable or disable DLC mods based on the `DLC_SPACE_AGE` environment variable.
* [`docker/files/docker-entrypoint.sh`](diffhunk://#diff-5059e07616398154e76917ec909b56bf7b9faa8ef9db6ff76c8c358f46eac950R46-R47): Updated the entry point script to call the new `docker-dlc.sh` script, ensuring DLC mods are configured at startup.

Fixes #510 
Related #https://github.com/m-chandler/factorio-spot-pricing/issues/40