### PR TITLE
Add documentation for env variable MODS and make it change mod directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,19 +261,20 @@ The `server-settings.json` file may then contain the variable references like th
 
 These are the environment variables which can be specified at container run time.
 
-| Variable Name        | Description                                                          | Default    | Available in |
-|----------------------|----------------------------------------------------------------------|------------|--------------|
-| GENERATE_NEW_SAVE    | Generate a new save if one does not exist before starting the server | false      | 0.17+        |
-| LOAD_LATEST_SAVE     | Load latest when true. Otherwise load SAVE_NAME                      | true       | 0.17+        |
-| PORT                 | UDP port the server listens on                                       | 34197      | 0.15+        |
-| BIND                 | IP address (v4 or v6) the server listens on (IP\[:PORT])             |            | 0.15+        |
-| RCON_PORT            | TCP port the rcon server listens on                                  | 27015      | 0.15+        |
-| SAVE_NAME            | Name to use for the save file                                        | _autosave1 | 0.17+        |
-| TOKEN                | factorio.com token                                                   |            | 0.17+        |
-| UPDATE_MODS_ON_START | If mods should be updated before starting the server                 |            | 0.17+        |
-| USERNAME             | factorio.com username                                                |            | 0.17+        |
-| CONSOLE_LOG_LOCATION | Saves the console log to the specifies location                      |            |              |
-| DLC_SPACE_AGE        | Enables or disables the mods for DLC Space Age in mod-list.json      | true       | 2.0.8+       |
+| Variable Name        | Description                                                          | Default        | Available in |
+|----------------------|----------------------------------------------------------------------|----------------|--------------|
+| GENERATE_NEW_SAVE    | Generate a new save if one does not exist before starting the server | false          | 0.17+        |
+| LOAD_LATEST_SAVE     | Load latest when true. Otherwise load SAVE_NAME                      | true           | 0.17+        |
+| PORT                 | UDP port the server listens on                                       | 34197          | 0.15+        |
+| BIND                 | IP address (v4 or v6) the server listens on (IP\[:PORT])             |                | 0.15+        |
+| RCON_PORT            | TCP port the rcon server listens on                                  | 27015          | 0.15+        |
+| SAVE_NAME            | Name to use for the save file                                        | _autosave1     | 0.17+        |
+| TOKEN                | factorio.com token                                                   |                | 0.17+        |
+| UPDATE_MODS_ON_START | If mods should be updated before starting the server                 |                | 0.17+        |
+| USERNAME             | factorio.com username                                                |                | 0.17+        |
+| CONSOLE_LOG_LOCATION | Saves the console log to the specifies location                      |                |              |
+| DLC_SPACE_AGE        | Enables or disables the mods for DLC Space Age in mod-list.json      | true           | 2.0.8+       |
+| MODS                 | Mod directory to use                                                 | /factorio/mods | 2.0.10+      |
 
 **Note:** All environment variables are compared as strings
 

--- a/docker/files/docker-entrypoint.sh
+++ b/docker/files/docker-entrypoint.sh
@@ -102,6 +102,7 @@ FLAGS=(\
   --server-adminlist "$CONFIG/server-adminlist.json" \
   --rcon-password "$(cat "$CONFIG/rconpw")" \
   --server-id /factorio/config/server-id.json \
+  --mod-directory "$MODS" \
 )
 
 if [ -n "$CONSOLE_LOG_LOCATION" ]; then


### PR DESCRIPTION
# Description

Pass the `MODS` environment variable to the Factorio executable with the argument `--mod-directory`   
This make it possible to change the mod directory by only changing the variable.

# Context

The recent change for version 2.0.9 introduced a script to enable/disable Space Age mods. This broke my setup because I was using the argument `--mod-directory` to use a different folder. The script `docker-dlc.sh` couldn't find any `mod-list.json` file.

As a workaround without this change, it's possible to set the `MODS` variable and also set the `--mod-directory` argument. With this change, only the setting the `MODS` variable is required.