### PR TITLE
Create base mod-list.json if it does not exist

### DIFF
--- a/docker/files/docker-dlc.sh
+++ b/docker/files/docker-dlc.sh
@@ -4,9 +4,9 @@ set -eou pipefail
 # Path to the mod-list.json file
 MOD_LIST_FILE="$MODS/mod-list.json"
 
-if [[ ! -f $MODS/mod-list.json ]]; then
+if [[ ! -f "$MOD_LIST_FILE" ]]; then
   # Create the mod-list.json file if it doesn't exist
-  echo '{"mods":[{"name": "base","enabled": true}]}' > "$MOD_LIST_FILE"
+  echo '{"mods":[{"name":"base","enabled":true}]}' > "$MOD_LIST_FILE"
 fi
 
 enable_mod()

--- a/docker/files/docker-dlc.sh
+++ b/docker/files/docker-dlc.sh
@@ -4,6 +4,11 @@ set -eou pipefail
 # Path to the mod-list.json file
 MOD_LIST_FILE="$MODS/mod-list.json"
 
+if [[ ! -f $MODS/mod-list.json ]]; then
+  # Create the mod-list.json file if it doesn't exist
+  echo '{"mods":[{"name": "base","enabled": true}]}' > "$MOD_LIST_FILE"
+fi
+
 enable_mod()
 {
   echo "Enable mod $1 for DLC"


### PR DESCRIPTION
This pull request includes a small change to the `docker/files/docker-dlc.sh` file. The change ensures that the `mod-list.json` file is created if it does not already exist.

* [`docker/files/docker-dlc.sh`](diffhunk://#diff-1d00cf54e20862293ddcb244a1557d9bb2a2b77e92eca21161323c51944c3605R7-R11): Added a check to create the `mod-list.json` file with a default configuration if it doesn't exist.

Fixes #522