### PR TITLE
Change DLC_SPACE_AGE to enable specific Space Age mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Use the `PORT` environment variable to start the server on the a different port,
 * [jaredledvina](https://github.com/jaredledvina/docker_factorio_server) - Contributed version updates
 * [carlbennett](https://github.com/carlbennett) - Contributed version updates and bugfixes
 
-[^1]: Space Age mods can be individually enabled by using their name separated by space.  
-  Example 1: Enable all `space-age elevated-rails quality`  
-  Example 2: Enable only Elevated rails `elevated-rails`
+[^1]: Space Age mods can also be individually enabled by using their name separated by space.  
+  Example 1: Enable all by using `true`
+  Example 2: Enable all by listing the mod names `space-age elevated-rails quality`  
+  Example 3: Enable only Elevated rails `elevated-rails`

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ These are the environment variables which can be specified at container run time
 | UPDATE_MODS_ON_START | If mods should be updated before starting the server                 |                | 0.17+        |
 | USERNAME             | factorio.com username                                                |                | 0.17+        |
 | CONSOLE_LOG_LOCATION | Saves the console log to the specifies location                      |                |              |
-| DLC_SPACE_AGE        | Enables or disables the mods for DLC Space Age in mod-list.json      | true           | 2.0.8+       |
+| DLC_SPACE_AGE        | Enables or disables the mods for DLC Space Age in mod-list.json[^1]  | true           | 2.0.8+       |
 | MODS                 | Mod directory to use                                                 | /factorio/mods | 2.0.8+       |
 
 **Note:** All environment variables are compared as strings
@@ -431,3 +431,7 @@ Use the `PORT` environment variable to start the server on the a different port,
 * [bplein](https://github.com/bplein/docker_factorio_server) - Coded scenario support
 * [jaredledvina](https://github.com/jaredledvina/docker_factorio_server) - Contributed version updates
 * [carlbennett](https://github.com/carlbennett) - Contributed version updates and bugfixes
+
+[^1]: Space Age mods can be individually enabled by using their name separated by space.  
+  Example 1: Enable all `space-age elevated-rails quality`  
+  Example 2: Enable only Elevated rails `elevated-rails`

--- a/docker/files/docker-dlc.sh
+++ b/docker/files/docker-dlc.sh
@@ -4,6 +4,8 @@ set -eou pipefail
 # Path to the mod-list.json file
 MOD_LIST_FILE="$MODS/mod-list.json"
 
+ALL_SPACE_AGE_MODS=("elevated-rails" "quality" "space-age")
+
 if [[ ! -f "$MOD_LIST_FILE" ]]; then
   # Create the mod-list.json file if it doesn't exist
   echo '{"mods":[{"name":"base","enabled":true}]}' > "$MOD_LIST_FILE"
@@ -26,18 +28,30 @@ disable_mod()
 # Enable or disable DLCs if configured
 if [[ ${DLC_SPACE_AGE:-} == "true" ]]; then
   # Define the DLC mods
-  DLC_MODS=("elevated-rails" "quality" "space-age")
-
-  # Iterate over each DLC mod
-  for MOD in "${DLC_MODS[@]}"; do
-    enable_mod "$MOD"
-  done
-else
+  ENABLE_MODS=(${ALL_SPACE_AGE_MODS[@]})
+elif [[ ${DLC_SPACE_AGE:-} == "false" ]]; then
   # Define the DLC mods
-  DLC_MODS=("elevated-rails" "quality" "space-age")
+  DISABLE_MODS=(${ALL_SPACE_AGE_MODS[@]})
+else
+  ENABLE_MODS=()
+  DISABLE_MODS=()
 
-  # Iterate over each DLC mod
-  for MOD in "${DLC_MODS[@]}"; do
-    disable_mod "$MOD"
+  for SPACE_AGE_MOD in "${ALL_SPACE_AGE_MODS[@]}"; do
+    REGEX="(^|\s)$SPACE_AGE_MOD($|\s)"
+    if [[ "$DLC_SPACE_AGE" =~ $REGEX ]]; then
+      ENABLE_MODS+=($SPACE_AGE_MOD)
+    else
+      DISABLE_MODS+=($SPACE_AGE_MOD)
+    fi
   done
 fi
+
+# Iterate over each DLC mod to enable
+for MOD in "${ENABLE_MODS[@]}"; do
+  enable_mod "$MOD"
+done
+
+# Iterate over each DLC mod to disable
+for MOD in "${DISABLE_MODS[@]}"; do
+  disable_mod "$MOD"
+done


### PR DESCRIPTION
fix #529

Instead of only `true` or `false`, the environment variable `DLC_SPACE_AGE` can be set to the name of the Space Age mods to enable. The unlisted Space Age mods are disabled.

Any combination of the Space Age mods can be used:
- `space-age elevated-rails quality`
- `space-age elevated-rails `
- `space-age quality`
- `space-age`
- `elevated-rails quality`
- `elevated-rails`
- `quality`