### PR TITLE
Use Absolute Paths over Relative Paths for Scripts in Entrypoint

### DIFF
--- a/docker/files/docker-entrypoint.sh
+++ b/docker/files/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eoux pipefail
+INSTALLED_DIRECTORY=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 FACTORIO_VOL=/factorio
 LOAD_LATEST_SAVE="${LOAD_LATEST_SAVE:-true}"
 GENERATE_NEW_SAVE="${GENERATE_NEW_SAVE:-false}"
@@ -40,10 +41,10 @@ if [[ $NRTMPSAVES -gt 0 ]]; then
 fi
 
 if [[ ${UPDATE_MODS_ON_START:-} == "true" ]]; then
-  ./docker-update-mods.sh
+  ${INSTALLED_DIRECTORY}/docker-update-mods.sh
 fi
 
-./docker-dlc.sh
+${INSTALLED_DIRECTORY}/docker-dlc.sh
 
 EXEC=""
 if [[ $(id -u) == 0 ]]; then


### PR DESCRIPTION
With the current use of relative paths in the Docker entrypoint script the user is _forced_ to run the `docker-entrypoint.sh` script from the root of the filesystem in the container. While this is fine for production I'm trying to use the Factorio container image as a basis for a devcontainer for mod development and would prefer to not have to `cd` to the root of the filesystem to start the server.

I've tested this locally by building the container image and starting the server from both the root of the filesystem as well as from another directory (in my case I used `/tmp`) and saw that I was able to start the server from either of them.