### PR TITLE
Added extra_host example for NAS

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,6 +24,6 @@ services:
 #      - ADDR=::1
 
 #    # Uncomment the following line to enable the use of the host's network stack,
-#    # which may be necessary for some setups like NAS.
+#    # which may be necessary for some setups like NAS or when using some proxy service like firewall rules.
 #    extra_hosts:
 #      - "host.docker.internal:host-gateway"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,3 +22,8 @@ services:
 #      - PORT=34198
 #      - PRESET=deathworld
 #      - ADDR=::1
+
+#    # Uncomment the following line to enable the use of the host's network stack,
+#    # which may be necessary for some setups like NAS.
+#    extra_hosts:
+#      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
This pull request includes a change to the `docker/docker-compose.yml` file to provide an option for using the host's network stack, which can be necessary for certain setups such as NAS.

Networking configuration:

* [`docker/docker-compose.yml`](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03R25-R29): Added commented-out configuration for `extra_hosts` to enable the use of the host's network stack.

Fixes #536