### PR TITLE
Added MOD_LIST_MAP environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ These are the environment variables which can be specified at container run time
 | USERNAME             | factorio.com username                                                |                | 0.17+        |
 | CONSOLE_LOG_LOCATION | Saves the console log to the specifies location                      |                |              |
 | DLC_SPACE_AGE        | Enables or disables the mods for DLC Space Age in mod-list.json[^1]  | true           | 2.0.8+       |
+| MOD_LIST_MAP         | String map of mod names to enable[^2]                                |                | 2.0.14+      |
 | MODS                 | Mod directory to use                                                 | /factorio/mods | 2.0.8+       |
 
 **Note:** All environment variables are compared as strings
@@ -437,3 +438,5 @@ Use the `PORT` environment variable to start the server on the a different port,
   Example 1: Enable all by using `true`
   Example 2: Enable all by listing the mod names `space-age elevated-rails quality`  
   Example 3: Enable only Elevated rails `elevated-rails`
+[^2]: All mods must be included in the string map (including wanted DLC mods).  
+  Example: "space-age elevated-rails quality flib helmod MaxRateCalculator RateCalculator"

--- a/docker/files/docker-dlc.sh
+++ b/docker/files/docker-dlc.sh
@@ -26,7 +26,12 @@ disable_mod()
 }
 
 # Enable or disable DLCs if configured
-if [[ ${DLC_SPACE_AGE:-} == "true" ]]; then
+if [[ -n "$MOD_LIST_MAP" ]]; then
+  # if MOD_LIST_MAP env variable is defined, then use it to determine the mods to enable
+  for mod in $MOD_LIST_MAP; do
+      ENABLE_MODS+=("$mod")
+  done
+elif [[ ${DLC_SPACE_AGE:-} == "true" ]]; then
   # Define the DLC mods
   ENABLE_MODS=(${ALL_SPACE_AGE_MODS[@]})
 elif [[ ${DLC_SPACE_AGE:-} == "false" ]]; then


### PR DESCRIPTION
The docker-dlc.sh script always overwrites the $MODS/mod-list.json file. This make it impossible to use any mods outside of the 3 defined in https://github.com/factoriotools/factorio-docker/blob/master/docker/files/docker-dlc.sh.

This pull request includes updates to the README.md file to document the new environment variable's use and the addition of a new optional environment variable to extend the docker-dlc.sh script.

Fixes https://github.com/factoriotools/factorio-docker/issues/544