### PR TITLE
Fix duplicate mod error with Space Age DLC mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Copy mods into the mods folder and restart the server.
 
 As of 0.17 a new environment variable was added ``UPDATE_MODS_ON_START`` which if set to ``true`` will cause the mods get to updated on server start. If set a valid [Factorio Username and Token](https://www.factorio.com/profile) must be supplied or else the server will not start. They can either be set as docker secrets, environment variables, or pulled from the server-settings.json file.
 
+**Note:** When using the Space Age DLC, the built-in mods (`elevated-rails`, `quality`, and `space-age`) are automatically skipped during mod updates to prevent conflicts. These mods are included with the DLC and should not be downloaded separately.
+
 ### Scenarios
 
 If you want to launch a scenario from a clean start (not from a saved map) you'll need to start the docker image from an alternate entrypoint. To do this, use the example entrypoint file stored in the /factorio/entrypoints directory in the volume, and launch the image with the following syntax. Note that this is the normal syntax with the addition of the --entrypoint setting AND the additional argument at the end, which is the name of the Scenario in the Scenarios folder.

--- a/docker/files/update-mods.sh
+++ b/docker/files/update-mods.sh
@@ -227,9 +227,12 @@ update_mod()
   return 0
 }
 
+# Process all enabled mods from mod-list.json, but skip built-in mods
+# The Space Age DLC includes built-in mods (elevated-rails, quality, space-age) that should not be downloaded
 if [[ -f $MOD_DIR/mod-list.json ]]; then
   jq -r ".mods|map(select(.enabled))|.[].name" "$MOD_DIR/mod-list.json" | while read -r mod; do
-    if [[ $mod != base ]]; then
+    # Skip base mod and DLC built-in mods
+    if [[ $mod != base ]] && [[ $mod != elevated-rails ]] && [[ $mod != quality ]] && [[ $mod != space-age ]]; then
       update_mod "$mod" || true
     fi
   done


### PR DESCRIPTION
## Summary
- Fixes #576 by preventing the mod updater from attempting to download built-in DLC mods
- Skips `elevated-rails`, `quality`, and `space-age` mods during updates when `UPDATE_MODS_ON_START=true`
- Adds documentation explaining this behavior

## Problem
When `UPDATE_MODS_ON_START=true` is enabled with the Space Age DLC, the mod updater tries to download the DLC's built-in mods from mods.factorio.com, causing "Duplicate mod" errors on server startup.

## Solution
Modified the `update-mods.sh` script to skip downloading these three built-in mods, as they are already included with the Space Age DLC and should not be downloaded separately.

## Test plan
- [x] Test with `UPDATE_MODS_ON_START=true` and Space Age DLC enabled
- [x] Verify no "Duplicate mod" errors occur
- [x] Confirm other mods still update correctly
- [x] Check that DLC mods remain functional

🤖 Generated with [Claude Code](https://claude.ai/code)