### PR TITLE
Fix Docker build error by adding file package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ ENV PORT=34197 \
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 RUN apt-get -q update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -qy install ca-certificates curl jq pwgen xz-utils procps gettext-base --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qy install ca-certificates curl jq pwgen xz-utils procps gettext-base file --no-install-recommends \
     && if [[ "$(uname -m)" == "aarch64" ]]; then \
         echo "installing ARM compatability layer" \
         && DEBIAN_FRONTEND=noninteractive apt-get -qy install unzip --no-install-recommends \ 


### PR DESCRIPTION
## Summary

This PR fixes the immediate Docker build error that has been causing GitHub Actions failures since June 2025.

## Problem

The Docker builds have been failing with the error:
```
/bin/bash: line 1: file: command not found
```

This occurs in the Dockerfile when the SHA256 checksum verification fails. The error handling tries to run the `file` command to help debug what was downloaded, but this command is not available in the `debian:stable-slim` base image.

## Solution

This PR adds the `file` package to the apt-get install list in the Dockerfile. This ensures that when SHA256 verification fails, we get proper debugging information about what was actually downloaded.

## Note

While this fixes the immediate error and will provide better diagnostics, it doesn't address the root cause of why the SHA256 checksums are failing in GitHub Actions. The builds work fine locally, suggesting the issue may be:
- Network/connectivity issues in GitHub Actions
- Rate limiting from Factorio download servers
- Issues specific to multi-architecture builds

Once this PR is merged and we can see the actual `file` output from failed builds, we'll have better information to diagnose and fix the underlying issue.

## Testing

- Built the Docker image locally with version 2.0.60 - works successfully
- Verified the `file` package is installed and available

Fixes the error seen in: https://github.com/factoriotools/factorio-docker/actions/runs/16195692533/job/45721490011

🤖 Generated with [Claude Code](https://claude.ai/code)