### PR TITLE
Fix Docker build failure: Replace addgroup/adduser with groupadd/useradd

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,8 +54,8 @@ RUN apt-get -q update \
     fi \
     && rm -rf /var/lib/apt/lists/*
 
-RUN addgroup --system --gid "$PGID" "$GROUP" \
-    && adduser --system --uid "$PUID" --gid "$PGID" --no-create-home --disabled-password --shell /bin/sh "$USER"
+RUN groupadd --system --gid "$PGID" "$GROUP" \
+    && useradd --system --uid "$PUID" --gid "$PGID" --no-create-home --shell /bin/sh "$USER"
 
 # version checksum of the archive to download
 ARG VERSION


### PR DESCRIPTION
## Description
This PR fixes the Docker build failure that occurred after the previous RCON fix was merged.

## Problem
The build was failing with:
```
/bin/bash: line 1: addgroup: command not found
```

This happened because the `addgroup` and `adduser` commands are not available in the `debian:stable-slim` base image. These commands are part of the `adduser` package which is not installed in slim images.

## Solution
Replace `addgroup` and `adduser` with their lower-level equivalents `groupadd` and `useradd` which are available in the base image:
- `addgroup --system --gid "$PGID" "$GROUP"` → `groupadd --system --gid "$PGID" "$GROUP"`
- `adduser --system --uid "$PUID" --gid "$PGID" --no-create-home --disabled-password --shell /bin/sh "$USER"` → `useradd --system --uid "$PUID" --gid "$PGID" --no-create-home --shell /bin/sh "$USER"`

The `--disabled-password` flag is not needed with `useradd` as it doesn't set a password by default.

## Testing
- Tested the Docker build locally - build completes successfully
- The RCON builder stage works correctly
- User and group creation succeeds

## Related Issues
Continues fix for #582 - This is the second part of fixing the build pipeline

## Impact
This will allow the Docker images to be built and deployed successfully, finally enabling users to get the latest Factorio version (2.0.64).