### PR TITLE
Remove unneccessary access token from update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        with:
-          token: ${{ secrets.REPO_TOKEN }}
 
       - name: Run update script
         run: ./update.sh


### PR DESCRIPTION
It is not necessary to use a personal access token (PAT) for this action. Because it is defined, the PAT eventually will expire and the action will stop working as it has now. By leaving it empty, Github populates a one-time token at the start of the workflow that will work for this repo for the purpose of the action.