### PR TITLE
Use REPO_PAT for update workflow checkout token

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.REPO_PAT }}
 
       - name: Run update script
         run: ./update.sh


### PR DESCRIPTION
Solves #602 and lingering issue in #595
This pull request changes the usage of the default github token to a PAT in order to be able to automatically trigger the build process in the update action.

NOTE: For this pull request to work it is necessary to add a fine grained PAT with the name "REPO_PAT" to the repository secrets with the following settings: Access to the factoriotools//factorio-docker repository and permissions:  Read and Write access to code and pull requests,  Read access to metadata. 