### PR TITLE
Trigger docker build when buildinfo.json is updated

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - buildinfo.json
+  workflow_call:
   # workaround for #526
   workflow_dispatch:
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,11 +9,32 @@ jobs:
   check:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'factoriotools/factorio-docker')
+    outputs:
+      updated: ${{ steps.changes.outputs.updated }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Save current HEAD
+        id: before
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Run update script
         run: ./update.sh
         shell: bash
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if [ "$(git rev-parse HEAD)" != "${{ steps.before.outputs.sha }}" ]; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: check
+    if: needs.check.outputs.updated == 'true'
+    uses: ./.github/workflows/docker-build.yml
+    secrets: inherit


### PR DESCRIPTION
The buildinfo.json is correctly updated. As can be seen here: https://github.com/factoriotools/factorio-docker/commit/18a4834158f08bf157311e6a1f54cc4ecbdccf43

The build and push pipeline is not triggered though: https://github.com/factoriotools/factorio-docker/actions/workflows/docker-build.yml . It was last manually triggered in January.

After merging this, updating the buildinfo.json also triggers the build pipeline. **For 2.0.76 is to be triggered manually one last time.**

There is another PR #610 that attempts something similar. Putting the trigger on the update pipeline rather than the other way around, saves a lot of unnecessary runs (even if only skips).