### PR TITLE
Fix checkout ref for build workflow call

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,9 +17,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: build and push all images
         if: ${{ env.DOCKER_USERNAME != '' && env.DOCKER_PASSWORD != '' }}


### PR DESCRIPTION
## Motivation

With #611, the build trigger was changed to a workflow_call, if the update action finds an update and pushes a commit.

However, this approach has a flaw, mainly that the build action will checkout the commit based on the event that triggered the workflow in the first place - so now the parent of the commit pushed.

This leads to the repo being in the correct state, but the workflow picking up the previous one and not pushing the correct image.

We can see that in this workflow run, the previous commit was checked out:

https://github.com/factoriotools/factorio-docker/actions/runs/26247031594/job/77247980413#step:2:65

This is also documented in https://github.com/actions/checkout:

> The branch, tag or SHA to checkout. When checking out the repository that
> triggered a workflow, this defaults to the reference or SHA for that event.
> Otherwise, uses the default branch.

## Changes

* Change the checkout ref for the build call to `${{ github.ref_name }}` - this should be, on the schedule action, the default branch (here `master`). This way we should get the latest commit (since it is already pushed to master).
* Update the setup-qemu-action: The current version uses node20, which is deprecated
